### PR TITLE
fix: over-aggressive contraction rule

### DIFF
--- a/docs/simulating.md
+++ b/docs/simulating.md
@@ -1,7 +1,7 @@
 # Simulating on the Command Line
 
 Simulating protocols requires the `opentrons` package installed.
-The best way to do that's to get it from Python's
+The best way to do that, is to get it from Python's
 package manager, `pip`.
 
 


### PR DESCRIPTION
the "always use contractions" rule got a little exited with this one... probably could be worded better in a future revision